### PR TITLE
Centralize checkpoint storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ for pretraining, finetuning and saliency map generation.
 - `saliency/` – utilities for generating saliency maps with Captum
 - `scripts/` – entry points that load a YAML config and launch a job
 - `configs/` – example configuration files
+- `checkpoints/` – default location for saved models
 
 ## Usage
 
@@ -25,7 +26,7 @@ python scripts/pretrain.py configs/pretrain.yaml
 ```
 
 Edit `configs/pretrain.yaml` so that `data_list` points to a list of training
-volumes. The script will save checkpoints under `ssl_runs/` and log metrics via
+volumes. The script will save checkpoints under `checkpoints/ssl_runs/` and log metrics via
 Weights & Biases.
 
 ### Finetuning on edema labels
@@ -47,3 +48,10 @@ python scripts/saliency.py configs/saliency.yaml
 Specify the classifier checkpoint via `ckpt` and the dataset list via
 `data_list`. Saliency maps will be written as NumPy arrays to the directory
 given in `out_dir`.
+
+### Checkpoints
+
+All training jobs write their outputs inside `checkpoints/`. Pretraining runs
+create a subfolder `ssl_runs/<run_id>` while finetuning creates
+`runs/<run_id>`. Configuration files may specify checkpoints relative to this
+directory via the `ckpt_dir` field.

--- a/configs/finetune.yaml
+++ b/configs/finetune.yaml
@@ -1,4 +1,5 @@
 project: Embryo_Edema_Classification
+ckpt_dir: checkpoints
 mean: 1776.835584
 std: 5603.538718
 out_channels: 64

--- a/configs/pretrain.yaml
+++ b/configs/pretrain.yaml
@@ -1,4 +1,5 @@
 project: SSL_Embryo_M3T_HYBRID
+ckpt_dir: checkpoints
 mean: 1776.835584
 std: 5603.538718
 out_channels: 64

--- a/configs/saliency.yaml
+++ b/configs/saliency.yaml
@@ -1,4 +1,5 @@
 mean: 1776.835584
+ckpt_dir: checkpoints
 std: 5603.538718
 out_channels: 64
 emb_size: 256

--- a/saliency/generate_maps.py
+++ b/saliency/generate_maps.py
@@ -21,7 +21,10 @@ def generate_maps(cfg: dict) -> None:
     loader = DataLoader(NRRDDataset(cfg['data_list'], tf), batch_size=1, shuffle=False)
 
     model = M3T_Edema(cfg).to(device)
-    ckpt = torch.load(cfg['ckpt'], map_location=device)
+    ckpt_path = cfg['ckpt']
+    if not os.path.isabs(ckpt_path):
+        ckpt_path = os.path.join(cfg.get('ckpt_dir', 'checkpoints'), ckpt_path)
+    ckpt = torch.load(ckpt_path, map_location=device)
     model.load_state_dict(ckpt['model'], strict=True)
     model.eval(); [p.requires_grad_(False) for p in model.parameters()]
 

--- a/training/finetune.py
+++ b/training/finetune.py
@@ -19,7 +19,8 @@ def run_finetuning_edema(cfg: dict) -> None:
     """Fine-tune the encoder on labeled data for edema classification."""
 
     wandb.init(project=cfg['project'], config=cfg)
-    run_dir = os.path.join('runs', wandb.run.name or wandb.run.id)
+    ckpt_root = cfg.get('ckpt_dir', 'checkpoints')
+    run_dir = os.path.join(ckpt_root, 'runs', wandb.run.name or wandb.run.id)
     os.makedirs(run_dir, exist_ok=True)
 
     train_tf, val_tf = build_transforms(cfg['mean'], cfg['std'])[:2]
@@ -36,10 +37,14 @@ def run_finetuning_edema(cfg: dict) -> None:
                                   'p_transformer','p_drop_path')}
     model = M3T_Edema(enc_cfg).to(device)
 
-    if cfg.get('ssl_ckpt') and os.path.isfile(cfg['ssl_ckpt']):
-        ckpt = torch.load(cfg['ssl_ckpt'], map_location='cpu')
-        msg  = model.encoder.load_state_dict(ckpt['encoder'], strict=False)
-        print(f"Loaded SSL weights with {len(msg.missing_keys)} missing keys")
+    ssl_path = cfg.get('ssl_ckpt')
+    if ssl_path:
+        if not os.path.isabs(ssl_path):
+            ssl_path = os.path.join(ckpt_root, ssl_path)
+        if os.path.isfile(ssl_path):
+            ckpt = torch.load(ssl_path, map_location='cpu')
+            msg  = model.encoder.load_state_dict(ckpt['encoder'], strict=False)
+            print(f"Loaded SSL weights with {len(msg.missing_keys)} missing keys")
 
     optimizer = optim.Adam(model.parameters(), lr=cfg['lr'])
     scheduler = CosineAnnealingLR(optimizer, T_max=cfg['epochs'])
@@ -105,7 +110,8 @@ def run_finetuning_exencephaly(cfg: dict) -> None:
     """Fine-tune the encoder for exencephaly classification."""
 
     wandb.init(project=cfg['project'], config=cfg)
-    run_dir = os.path.join('runs', wandb.run.name or wandb.run.id)
+    ckpt_root = cfg.get('ckpt_dir', 'checkpoints')
+    run_dir = os.path.join(ckpt_root, 'runs', wandb.run.name or wandb.run.id)
     os.makedirs(run_dir, exist_ok=True)
 
     train_tf, val_tf = build_transforms(cfg['mean'], cfg['std'])[:2]
@@ -123,10 +129,14 @@ def run_finetuning_exencephaly(cfg: dict) -> None:
         'p_transformer', 'p_drop_path')}
     model = M3T_Exencephaly(enc_cfg).to(device)
 
-    if cfg.get('ssl_ckpt') and os.path.isfile(cfg['ssl_ckpt']):
-        ckpt = torch.load(cfg['ssl_ckpt'], map_location='cpu')
-        msg = model.encoder.load_state_dict(ckpt['encoder'], strict=False)
-        print(f"Loaded SSL weights with {len(msg.missing_keys)} missing keys")
+    ssl_path = cfg.get('ssl_ckpt')
+    if ssl_path:
+        if not os.path.isabs(ssl_path):
+            ssl_path = os.path.join(ckpt_root, ssl_path)
+        if os.path.isfile(ssl_path):
+            ckpt = torch.load(ssl_path, map_location='cpu')
+            msg = model.encoder.load_state_dict(ckpt['encoder'], strict=False)
+            print(f"Loaded SSL weights with {len(msg.missing_keys)} missing keys")
 
     optimizer = optim.Adam(model.parameters(), lr=cfg['lr'])
     scheduler = CosineAnnealingLR(optimizer, T_max=cfg['epochs'])
@@ -194,7 +204,8 @@ def run_finetuning_gli2(cfg: dict) -> None:
     """Fine-tune the encoder for Gli2 classification."""
 
     wandb.init(project=cfg['project'], config=cfg)
-    run_dir = os.path.join('runs', wandb.run.name or wandb.run.id)
+    ckpt_root = cfg.get('ckpt_dir', 'checkpoints')
+    run_dir = os.path.join(ckpt_root, 'runs', wandb.run.name or wandb.run.id)
     os.makedirs(run_dir, exist_ok=True)
 
     train_tf, val_tf = build_transforms(cfg['mean'], cfg['std'])[:2]
@@ -212,10 +223,14 @@ def run_finetuning_gli2(cfg: dict) -> None:
         'p_transformer', 'p_drop_path')}
     model = M3T_Gli2(enc_cfg).to(device)
 
-    if cfg.get('ssl_ckpt') and os.path.isfile(cfg['ssl_ckpt']):
-        ckpt = torch.load(cfg['ssl_ckpt'], map_location='cpu')
-        msg = model.encoder.load_state_dict(ckpt['encoder'], strict=False)
-        print(f"Loaded SSL weights with {len(msg.missing_keys)} missing keys")
+    ssl_path = cfg.get('ssl_ckpt')
+    if ssl_path:
+        if not os.path.isabs(ssl_path):
+            ssl_path = os.path.join(ckpt_root, ssl_path)
+        if os.path.isfile(ssl_path):
+            ckpt = torch.load(ssl_path, map_location='cpu')
+            msg = model.encoder.load_state_dict(ckpt['encoder'], strict=False)
+            print(f"Loaded SSL weights with {len(msg.missing_keys)} missing keys")
 
     optimizer = optim.Adam(model.parameters(), lr=cfg['lr'])
     scheduler = CosineAnnealingLR(optimizer, T_max=cfg['epochs'])

--- a/training/pretrain.py
+++ b/training/pretrain.py
@@ -20,7 +20,8 @@ def run_pretraining(cfg: dict) -> None:
     """Run BYOL pretraining with additional SSL objectives."""
 
     wandb.init(project=cfg['project'], config=cfg)
-    run_dir = os.path.join("ssl_runs", wandb.run.name or wandb.run.id)
+    ckpt_root = cfg.get('ckpt_dir', 'checkpoints')
+    run_dir = os.path.join(ckpt_root, "ssl_runs", wandb.run.name or wandb.run.id)
     os.makedirs(run_dir, exist_ok=True)
 
     load_tf, aug_v1, aug_v2 = build_transforms(cfg['mean'], cfg['std'])


### PR DESCRIPTION
## Summary
- add default `checkpoints/` directory
- make all configs include a `ckpt_dir` field
- update training code to write runs under the checkpoint directory
- resolve checkpoint paths relative to `ckpt_dir`
- update saliency loader to respect `ckpt_dir`
- document checkpoint layout in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683dce6cef348327af35a96747bcc28f