### PR TITLE
Improve config generation with stratified split

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ linear warmup controlled by `warmup_epochs`.
 
 The script `scripts/generate_configs.py` can create a finetuning YAML file
 directly from a CSV table of sample labels. It scans a directory of NRRD files,
-splits the dataset and computes intensity statistics.
+splits the dataset with a **stratified** shuffle to preserve class ratios and
+computes intensity statistics.
 
 ```bash
 python scripts/generate_configs.py \


### PR DESCRIPTION
## Summary
- keep class ratios in train/validation splits
- document new behaviour in README

## Testing
- `python3 -m py_compile scripts/generate_configs.py`
- `python3 scripts/generate_configs.py --help` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_683de2be42c08327b2bdea6b34e944ee