### PR TITLE
Add project injection during config generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ training volumes. The script writes checkpoints to
 `checkpoints/ssl_runs/<run_id>` and logs metrics via Weights & Biases. The final
 encoder weights can then be used for supervised finetuning.
 
-### Finetuning on edema labels
+### Finetuning
 
-Finetuning configs are generated for each task. The file
-`configs/finetune.yaml` acts only as a base template and cannot be used
-directly. First create a task specific config (see below) and then run:
+Finetuning configs are generated for each classification task. The file
+`configs/finetune.yaml` is a generic template without any dataset
+information or Weights & Biases project. First create a task specific
+config with `scripts/generate_configs.py` (see below) and then run:
 
 ```bash
-python scripts/finetune.py configs/edema_finetune.yaml
+python scripts/finetune.py configs/edema_finetune.yaml  # replace with your task
 ```
 
 The generated YAML contains the dataset lists and can optionally reference a
@@ -53,7 +54,8 @@ computes intensity statistics.
 
 ```bash
 python scripts/generate_configs.py \
-    --task edema \
+    --task edema \  # replace with your task
+    --project MyWandBProject \
     --csv path/to/labels.csv \
     --data-dir /path/to/nrrd \
     --ssl-ckpt ssl_runs/<run_id>/ssl_backbone_final.pth \
@@ -61,8 +63,10 @@ python scripts/generate_configs.py \
 ```
 
 `--ssl-ckpt` should point to the pretraining checkpoint relative to
-`checkpoints/`. The resulting YAML can then be supplied to
-`scripts/finetune.py`.
+`checkpoints/`. The resulting YAML contains the dataset lists, intensity
+statistics, the selected `task` and the `project` name. If `--project` is
+omitted, a default name of the form `Embryo_<task>_Classification` is
+used. The config can then be supplied to `scripts/finetune.py`.
 
 ### Saliency map generation
 

--- a/configs/finetune.yaml
+++ b/configs/finetune.yaml
@@ -1,4 +1,3 @@
-project: Embryo_Edema_Classification
 ckpt_dir: checkpoints
 out_channels: 64
 emb_size: 256
@@ -14,3 +13,4 @@ lr: 1e-4
 warmup_epochs: 0
 save_every: 5
 ssl_ckpt: null
+

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -2,7 +2,11 @@
 
 import argparse
 import yaml
-from training.finetune import run_finetuning_edema
+from training.finetune import (
+    run_finetuning_edema,
+    run_finetuning_exencephaly,
+    run_finetuning_gli2,
+)
 
 if __name__ == '__main__':
     ap = argparse.ArgumentParser(description='Run classifier finetuning')
@@ -10,4 +14,13 @@ if __name__ == '__main__':
     args = ap.parse_args()
     with open(args.config) as f:
         cfg = yaml.safe_load(f)
-    run_finetuning_edema(cfg)
+
+    task = cfg.get('task', 'edema')
+    if task == 'edema':
+        run_finetuning_edema(cfg)
+    elif task == 'exencephaly':
+        run_finetuning_exencephaly(cfg)
+    elif task == 'gli2':
+        run_finetuning_gli2(cfg)
+    else:
+        raise ValueError(f"Unknown finetuning task: {task}")

--- a/scripts/generate_configs.py
+++ b/scripts/generate_configs.py
@@ -122,6 +122,7 @@ def main():
     ap = argparse.ArgumentParser(description='Generate finetuning config')
     ap.add_argument('--task', required=True, choices=['edema', 'exencephaly', 'gli2'],
                     help='Target classification task')
+    ap.add_argument('--project', help='Weights & Biases project name')
     ap.add_argument('--csv', required=True, help='CSV file with labels')
     ap.add_argument('--data-dir', required=True, help='Directory with NRRD volumes')
     ap.add_argument('--base-config', default=os.path.join('configs', 'finetune.yaml'),
@@ -134,6 +135,7 @@ def main():
     args = ap.parse_args()
 
     cfg = load_base_config(args.base_config)
+    cfg['task'] = args.task
     items = build_datalist(args.csv, args.data_dir, args.task)
     train_list, val_list = split_data(items, args.val_split, args.seed)
 
@@ -145,7 +147,10 @@ def main():
     cfg['val_split'] = args.val_split
     cfg['mean'] = mean
     cfg['std'] = std
-    cfg['project'] = cfg.get('project', '')
+    if args.project:
+        cfg['project'] = args.project
+    else:
+        cfg['project'] = f'Embryo_{args.task}_Classification'
     if args.ssl_ckpt:
         cfg['ssl_ckpt'] = args.ssl_ckpt
 


### PR DESCRIPTION
## Summary
- keep base finetune config generic
- allow `scripts/generate_configs.py` to set the project name
- document new behaviour in the README

## Testing
- `python -m py_compile scripts/finetune.py scripts/generate_configs.py training/finetune.py models/classifier.py training/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_683de8371dfc8327ab35ae4713036057