### PR TITLE
Document citations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,10 @@ All training jobs write their outputs inside `checkpoints/`. Pretraining runs
 create a subfolder `ssl_runs/<run_id>` while finetuning creates
 `runs/<run_id>`. Configuration files may specify checkpoints relative to this
 directory via the `ckpt_dir` field.
+
+## Citation
+
+If you use this repository, please cite:
+
+- Vishnu Vardhan Reddy Kanamata Reddy. *M3T*. DOI: 10.5281/zenodo.11204469.
+- Jang, J., & Hwang, D. (2022). M3T: three-dimensional medical image classifier using multi-plane and multi-slice transformer. In *Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition* (pp. 20718–20729).


### PR DESCRIPTION
## Summary
- remove CITATION.cff file
- document repository DOI and paper citation directly in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68965203e5448327b01d20d52cf8c545