### PR TITLE
Add conda environment file and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ for pretraining, finetuning and saliency map generation.
 - `configs/` – example configuration files
 - `checkpoints/` – default location for saved models
 
+## Environment setup
+
+This repository requires Python 3.10 and a number of packages such as
+PyTorch and MONAI. The easiest way to get started is to create the
+included conda environment:
+
+```bash
+conda env create -f environment.yml
+conda activate m3t
+```
+
+This installs PyTorch, MONAI, SimpleITK, SciPy and supporting imaging libraries
+like scikit-image and NiBabel required by the training and saliency scripts.
+
 ## Usage
 
 The project is configured through YAML files located in `configs/`. Each script

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,23 @@
+name: m3t
+channels:
+  - pytorch
+  - conda-forge
+dependencies:
+  - python=3.10
+  - pytorch
+  - torchvision
+  - numpy
+  - pandas
+  - pyyaml
+  - tqdm
+  - scipy
+  - scikit-image
+  - nibabel
+  - pillow
+  - pip
+  - pip:
+      - monai
+      - einops
+      - wandb
+      - captum
+      - SimpleITK


### PR DESCRIPTION
## Summary
- add `environment.yml` defining Python 3.10 environment with PyTorch, MONAI and other dependencies
- document environment creation and activation in the README
- expand environment dependencies to include SciPy and related imaging libraries

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689657d5f3348327ac2f2e953dd5a08f