### PR TITLE
Add placeholder directories for FL-SMALL dataset

### DIFF
--- a/FL-SMALL/masked_cubes144_labeled_nrrd/.gitkeep
+++ b/FL-SMALL/masked_cubes144_labeled_nrrd/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for Git to track directory

--- a/FL-SMALL/splits/.gitkeep
+++ b/FL-SMALL/splits/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for Git to track directory


### PR DESCRIPTION
## Summary
- add masked_cubes144_labeled_nrrd and splits directories to FL-SMALL with placeholder files so they are tracked by git

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689be99957fc832798b3852d99ff9d40