### PR TITLE
Document FL-SMALL training workflow

### DIFF
--- a/FL-SMALL/train_exencephaly_FL-SMALL.py
+++ b/FL-SMALL/train_exencephaly_FL-SMALL.py
@@ -382,7 +382,8 @@ def main():
         f.write(str(SEED))
 
     # ------------------------- dataset file list -------------------
-    folder = "FL-SMALL/masked_cubes144_labeled_nrrd"
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    folder = os.path.join(base_dir, "masked_cubes144_labeled_nrrd")
     rx = re.compile(r"(Scan_\d{4}).*?_(\d+)_([A-Za-z0-9]+)_(\w+)\.nrrd$")
     emap = {"FALSE":0,"False":0,"0":0,"TRUE":1,"True":1,"1":1}
     raw = []
@@ -396,7 +397,7 @@ def main():
         raise RuntimeError("No NRRDs found.")
 
     # ------------------------- train/val split ---------------------
-    splits_dir = "FL-SMALL/splits"
+    splits_dir = os.path.join(base_dir, "splits")
     os.makedirs(splits_dir, exist_ok=True)
     tr_file  = os.path.join(splits_dir, f"exencephaly_train_idx_seed{SEED}.npy")
     val_file = os.path.join(splits_dir, f"exencephaly_val_idx_seed{SEED}.npy")

--- a/README.md
+++ b/README.md
@@ -99,6 +99,35 @@ create a subfolder `ssl_runs/<run_id>` while finetuning creates
 `runs/<run_id>`. Configuration files may specify checkpoints relative to this
 directory via the `ckpt_dir` field.
 
+### Training the FL-SMALL exencephaly model
+
+The directory `FL-SMALL/` contains a standalone script for training a single
+seed of the FL-SMALL model described in the preprint. To run it:
+
+1. Download the masked and labelled 144³ µCT cubes from the Box archive and
+   extract them into `FL-SMALL/masked_cubes144_labeled_nrrd`:
+
+   https://app.box.com/s/uqkmfq5y821j91h0106ok0goxqq7fjbq
+
+2. Ensure the environment has been created and activate it:
+
+   ```bash
+   conda activate m3t
+   ```
+
+3. Launch the training script with a chosen seed (e.g. `0`):
+
+   ```bash
+   python FL-SMALL/train_exencephaly_FL-SMALL.py --seed 0
+   ```
+
+The script reads volumes from `FL-SMALL/masked_cubes144_labeled_nrrd`, creates
+or reuses a train/validation split under `FL-SMALL/splits`, and logs the run via
+Weights & Biases. Checkpoints and training curves are written to
+`runs/<timestamp>_<wandb_id>` alongside a `seed.txt` file containing the random
+seed. Subsequent runs with different seeds will generate their own split files
+and run directories.
+
 ## Citation
 
 If you use this repository, please cite:


### PR DESCRIPTION
## Summary
- Clarify how to train the FL-SMALL exencephaly model from this repo
- Ensure training script locates dataset and split folders regardless of working directory

## Testing
- `python3 -m py_compile FL-SMALL/train_exencephaly_FL-SMALL.py`


------
https://chatgpt.com/codex/tasks/task_e_689bede454008327b0de81839f41340a